### PR TITLE
changed MetaTags function to use AbsoluteLink instead of Link in Translatable.php

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1276,7 +1276,7 @@ class Translatable extends DataExtension implements PermissionProvider {
 			$tags .= sprintf($template,
 				Convert::raw2xml($translation->Title),
 				i18n::convert_rfc1766($translation->Locale),
-				$translation->Link()
+				$translation->AbsoluteLink()
 			);
 		}
 	}


### PR DESCRIPTION
modified MetaTags function to provide absolute links instead of using normal Link() method. This improves compatibility with the Translatable-Domains module and would provide accurate alternate href's to other locales that use subdomains or TLD's.
