### PR TITLE
BUG: Site tree sidebar not updated when creating a new translation

### DIFF
--- a/code/controller/TranslatableCMSMainExtension.php
+++ b/code/controller/TranslatableCMSMainExtension.php
@@ -98,6 +98,9 @@ class TranslatableCMSMainExtension extends Extension {
 			$langCode
 		);
 
+		// set the X-Pjax header to Content, so that the whole admin panel will be refreshed
+		$this->owner->getResponse()->addHeader('X-Pjax', 'Content');
+		
 		return $this->owner->redirect($url);
 	}
 


### PR DESCRIPTION
The site tree sidebar was not updated when creating a new translation,
due to only CurrentForm and Breadcrumbs fragments being updated by default.

Fixed by explicitly setting the X-Pjax response header to Content on
translation creation.
