### PR TITLE
FIXED: Error where uninitialised Locale field would crash queries.

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -539,7 +539,7 @@ class Translatable extends DataExtension implements PermissionProvider {
 		// If the record is saved (and not a singleton), and has a locale,
 		// limit the current call to its locale. This fixes a lot of problems
 		// with other extensions like Versioned
-		$locale = ($this->owner->ID && $this->owner->Locale) ? $this->owner->Locale : Translatable::get_current_locale();
+		$locale = ($this->owner->ID && !empty($this->owner->Locale)) ? $this->owner->Locale : Translatable::get_current_locale();
 		$baseTable = ClassInfo::baseDataClass($this->owner->class);
 		if(
 			$locale


### PR DESCRIPTION
Fixed an error where uninitialised Locale field would crash queries. This is noticeable during full text search, when models are instantiated with lazy loading.

I had setup a full text search form for my blog, and as full text search works, only sitetree default fields are returned up front, meaning lazy-loaded fields (e.g. Locale) can not be guaranteed to exist.

The error received:

```
Error retrieved: "ERROR [Notice]: Undefined property: BlogEntry::$Locale"
```

I simply substituted in an !empty() in the augmentSQL() function to safely check for existence of a Locale value instead of simply calling the field directly.
