### PR TITLE
BUG: locale dropdown sometimes hidden after panel reload

### DIFF
--- a/javascript/CMSMain.Translatable.js
+++ b/javascript/CMSMain.Translatable.js
@@ -30,6 +30,11 @@
 		 * whenever a new value is selected, reload the whole CMS in the new locale
 		 */
 		$('.CMSMain #Form_LangForm :input[name=Locale]').entwine({
+			onmatch: function() {
+				// make sure this element is shown, since it might be hidden by chosen before the panel is cached
+				$(this).show();
+				this._super();
+			},
 			onchange: function(e) {
 				var url = $.path.addSearchParams(
 					document.location.href.replace(/locale=[^&]*/, ''),


### PR DESCRIPTION
The locale dropdown was sometimes hidden after a panel reload via ajax,
due to the caching behaviour for the panel. This was caused by the fact
that the dropdown was hidden at the point in which the panel was cached
(probably due to chosen).
Fixed by always making sure the dropdown is shown on its onmatch function.
