### PR TITLE
BUG: double ajax request for page editing in default locale

### DIFF
--- a/code/controller/TranslatableCMSMainExtension.php
+++ b/code/controller/TranslatableCMSMainExtension.php
@@ -29,6 +29,11 @@ class TranslatableCMSMainExtension extends Extension {
 			if($record && $record->Locale) $this->owner->Locale = $record->Locale;
 		} else {
 			$this->owner->Locale = Translatable::default_locale();
+			if ($this->owner->class == 'CMSPagesController') {
+				// the CMSPagesController always needs to have the locale set, otherwise page editing will cause an extra
+				// ajax request which looks weird due to multiple "loading"-flashes
+				return $this->owner->redirect($this->owner->Link());
+			}
 		}
 		Translatable::set_current_locale($this->owner->Locale);
 


### PR DESCRIPTION
When editing a page in the default locale, a double ajax request was done for the editing page.
This was caused by no locale-parameter being set in this case, which caused the default locale
parameter to be added and a new ajax request was made due to this. The extra ajax request caused
the loading-animation to appear after the edit page was loaded, which looks weird.
Fixed by doing a redirect immediately the CMSPagesController is loaded and no locale is set, so
that the default locale parameter gets set at this stage.
