### PR TITLE
BUG: redirect to pages overview not working from page edit view

### DIFF
--- a/code/controller/TranslatableCMSMainExtension.php
+++ b/code/controller/TranslatableCMSMainExtension.php
@@ -44,7 +44,7 @@ class TranslatableCMSMainExtension extends Extension {
 					$transPage->ID
 					// ?locale will automatically be added
 				));
-			} else {
+			} else if ($this->owner->class != 'CMSPagesController') {
 				// If the record is not translated, redirect to pages overview
 				return $this->owner->redirect(Controller::join_links(
 					singleton('CMSPagesController')->Link(),


### PR DESCRIPTION
The redirect to pages overview was not working because the pages overview and page edit views
share the same session namespace, and therefore the checks to see if we need to redirect to
pages overview (i.e. if there is a translated record for the current page) matched also for
the redirected request.

Fixed by checking if we already are on the CMSPagesController before redirecting to it.
