### PR TITLE
BUG Do not populate defaults when updating schema.

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1193,10 +1193,10 @@ class Translatable extends DataExtension implements PermissionProvider {
 	 */
 	protected function populateSiteConfigDefaults() {
 		
-		// Work-around for population of defaults during database initialisation.
-		// When the database is being setup singleton('SiteConfig') is called.
-		if(!DB::getConn()->hasTable($this->owner->class)) return;
-		if(!DB::getConn()->hasField($this->owner->class, 'Locale')) return;
+		// When the database is being setup singleton('SiteConfig') is called,
+		// but the SiteConfig table might not be ready yet and the queries will break.
+		// Skip the population of defaults in this case.
+		if(DB::getConn()->isSchemaUpdating()) return;
 		
 		// Find the best base translation for SiteConfig
 		Translatable::disable_locale_filter();


### PR DESCRIPTION
This breaks the dev/build if the table is not ready or has been
modified. The default record will be created later anyway.

Dependent on https://github.com/silverstripe/sapphire/pull/883
