### PR TITLE
BUGFIX Ensure members can be created with individual locale setting.

### DIFF
--- a/code/controller/TranslatableCMSMainExtension.php
+++ b/code/controller/TranslatableCMSMainExtension.php
@@ -80,8 +80,8 @@ class TranslatableCMSMainExtension extends Extension {
 	}
 	
 	function updateEditForm(&$form) {
-		$siteConfig = SiteConfig::current_site_config();
 		if($form->getName() == 'RootForm' && Object::has_extension('SiteConfig',"Translatable")) {
+			$siteConfig = SiteConfig::current_site_config();
 			$form->Fields()->push(new HiddenField('Locale','', $siteConfig->Locale));
 		}
 	}


### PR DESCRIPTION
Current site config should not be requested before knowing it's required. This was also attempting to create a new translation of site config when creating a new member with a locale for which there wasn't a site config.
