### PR TITLE
Enhancements to translatable field transforms

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1758,7 +1758,9 @@ class Translatable_Transformation extends FormTransformation {
 	protected function transformCheckboxField(CheckboxField $nonEditableField, CheckboxField $originalField) {
 		$label = $originalField->Title();
 		$fieldName = $originalField->getName();
-		$value = ($this->original->$fieldName) ? _t('Translatable_Transform.CheckboxValueYes', 'Yes') : _t('Translatable_Transform.CheckboxValueNo', 'No');
+		$value = ($this->original->$fieldName) 
+			? _t('Translatable_Transform.CheckboxValueYes', 'Yes') 
+			: _t('Translatable_Transform.CheckboxValueNo', 'No');
 		$originalLabel = _t(
 			'Translatable_Transform.OriginalCheckboxLabel', 
 			'Original: {value}',


### PR DESCRIPTION
The default transform of fields done in `Translatable_Transformation->baseTransform` is suitable for the majority of fields (and as a default). It works well for field types like `TextField`, `TextareaField` and `HTMLEditorField`, but quite poorly for some others, the most obvious being `CheckboxField`.

These changes make it easier to modify how `Translatable_Transformation` transforms fields based on the field type, and implements a new transform for `CheckboxField` as a starting point.

An example of how `CheckboxFields` display on a translated page before and after application of this patch is attached.

![](http://cl.ly/N0dk/Image%202013-02-20%20at%201.22.17%20PM.png)
![](http://cl.ly/N1Ka/Image%202013-02-20%20at%201.02.55%20PM.png)
