### PR TITLE
FIX Retrieve list of translatable fields not database fields

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -533,7 +533,7 @@ class Translatable extends DataExtension implements PermissionProvider {
 		// setting translatable fields by inspecting owner - this should really be done in the constructor
 		if($this->owner && $this->translatableFields === null) {
 			$this->translatableFields = array_merge(
-				array_keys($this->owner->inheritedDatabaseFields()),
+				array_keys($this->owner->db()),
 				array_keys($this->owner->has_many()),
 				array_keys($this->owner->many_many()),
 				array_keys($this->owner->has_one())


### PR DESCRIPTION
There was a mismatch in which the **form field names** were being compared with **database column names** rather than **data object field names** when determining what fields are translatable.

Among other possible side effects, this error has the result that composite fields are made read-only rather than being translatable.
