### PR TITLE
BUG Cleaner handling of querystring arguments when selecting locale

### DIFF
--- a/code/controller/TranslatableCMSMainExtension.php
+++ b/code/controller/TranslatableCMSMainExtension.php
@@ -40,7 +40,7 @@ class TranslatableCMSMainExtension extends Extension {
 					$req->param('Action'),
 					$req->param('ID'),
 					$req->param('OtherID'),
-					'?' . http_build_query($getVars)
+					($query = http_build_query($getVars)) ? "?$query" : null
 				));
 			}
 		}

--- a/javascript/CMSMain.Translatable.js
+++ b/javascript/CMSMain.Translatable.js
@@ -36,10 +36,19 @@
 				this._super();
 			},
 			onchange: function(e) {
-				var url = $.path.addSearchParams(
-					document.location.href.replace(/locale=[^&]*/, ''),
-					{locale: $(e.target).val()}
-				);
+				// Get new locale code
+				locale = {locale: $(e.target).val()};
+				
+				// Check existing url
+				search = /locale=[^&]*/;
+				url = document.location.href;
+				if(url.match(search)) {
+					// Replace locale code
+					url = url.replace(search, $.param(locale));
+				} else {
+					// Add locale code
+					url = $.path.addSearchParams(url, locale);
+				}
 				$('.cms-container').loadPanel(url);
 				return false;
 			}


### PR DESCRIPTION
When selecting and redirecting to various locales (either by PHP or through javascript) url injection of the querystring argument "locale" acted poorly. Repeated changes of locale using the dropdown would disfigure the querystring into forms like "?&&&&&locale=en_NZ" or "?locale=en_NZ&" (with no conjoined querystring arguments).

This fix adds some more robust logic and cleaner handling of urls.
