### PR TITLE
merged $allCodes returns items with nested array

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1495,7 +1495,7 @@ class Translatable extends DataExtension implements PermissionProvider {
 		foreach ($langlist as $langCode) {
 			if($langCode && isset($allCodes[$langCode])) {
 				if(is_array($allCodes[$langCode])) {
-					$returnMap[$langCode] = $allCodes[$langCode][0];
+					$returnMap[$langCode] = $allCodes[$langCode]['name'];
 				} else {
 					$returnMap[$langCode] = $allCodes[$langCode];
 				}


### PR DESCRIPTION
items from the common_locales in line 1493 return nested array of "name"=>LangName,"native"=>NativeName.
need to make sure to pull the "name" parameter from the array for the $returnMap. 
Otherwise was returning:

[Notice] Undefined offset: 0

Might be a better way to do this... only a proposed fix :)
