### PR TITLE
FIX: TranslatableSearchFormTest used wrong param for getResults

### DIFF
--- a/tests/unit/TranslatableSearchFormTest.php
+++ b/tests/unit/TranslatableSearchFormTest.php
@@ -69,7 +69,7 @@ class TranslatableSearchFormTest extends FunctionalTest {
 		// through a pseudo GET variable in getResults()
 		
 		$lang = 'en_US';
-		$results = $sf->getResults(null, array('Search'=>'content', 'locale'=>$lang));
+		$results = $sf->getResults(null, array('Search'=>'content', 'searchlocale'=>$lang));
 		$this->assertContains(
 			$publishedPage->ID,
 			$results->column('ID'),
@@ -82,7 +82,7 @@ class TranslatableSearchFormTest extends FunctionalTest {
 		);
 		
 		$lang = 'de_DE';
-		$results = $sf->getResults(null, array('Search'=>'content', 'locale'=>$lang));
+		$results = $sf->getResults(null, array('Search'=>'content', 'searchlocale'=>$lang));
 		$this->assertNotContains(
 			$publishedPage->ID,
 			$results->column('ID'),


### PR DESCRIPTION
This fixes a test case that is failing in master (running against framework/cms 3.1 branches).
