### PR TITLE
BUG: with the enforcement of allowed_actions in 3.2 getLocaleForObject is blocked

### DIFF
--- a/code/forms/LanguageDropdownField.php
+++ b/code/forms/LanguageDropdownField.php
@@ -7,7 +7,7 @@
  */
 class LanguageDropdownField extends GroupedDropdownField {
 
-	public static $allowed_actions = array(
+	private static $allowed_actions = array(
 		'getLocaleForObject'
 	);
 	


### PR DESCRIPTION
In SilverStripe 3.2 allowed_actions is being enforced which was causing a issue when trying to insert a link via TinyMCE because getLocaleForObject is called when using the translatable module (used by the Language dropdown) a Forbidden warning was appearing.

The response from Network via inspect element in Chrome is below

Action 'getLocaleForObject' isn't allowed on class LanguageDropdownField.

Applying this patch fixed the error they may be other allowed actions that need to be added this patch just adds allowed_actions with getLocaleForObject
