### PR TITLE
ENHANCEMENT: significant speed improvement for many locales

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1010,12 +1010,11 @@ class Translatable extends DataExtension implements PermissionProvider {
 				));
 				if(!$tab->fieldByName('existingtrans')) {
 					$existingTransHTML = '<ul>';
-					foreach($alreadyTranslatedLocales as $langCode) {		
-						$existingTranslation = $this->owner->getTranslation($langCode);
+					foreach($this->getTranslations() as $existingTranslation) {
 						if($existingTranslation && $existingTranslation->hasMethod('CMSEditLink')) {
 							$existingTransHTML .= sprintf('<li><a href="%s">%s</a></li>',
-								sprintf('%s/?locale=%s', $existingTranslation->CMSEditLink(), $langCode),
-								i18n::get_locale_name($langCode)
+								sprintf('%s/?locale=%s', $existingTranslation->CMSEditLink(), $existingTranslation->Locale),
+								i18n::get_locale_name($existingTranslation->Locale)
 							);
 						}
 					}


### PR DESCRIPTION
Iterating over an array of locales and querying for each one causes tons
of unnecessary queries. This is especially evident when you get up to
hundreds of translations of a page. It makes the CMS admin UI insufferably
slow.  This is a little tweak to query for all of them at once instead of
individually.
