### PR TITLE
FIX: don't re-enable the locale filter if it wasn't enabled before

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1259,12 +1259,15 @@ class Translatable extends DataExtension implements PermissionProvider {
 		if(DB::getConn()->isSchemaUpdating()) return;
 		
 		// Find the best base translation for SiteConfig
+		$enabled = Translatable::locale_filter_enabled();
 		Translatable::disable_locale_filter();
 		$existingConfig = SiteConfig::get()->filter(array(
 			'Locale' => Translatable::default_locale()
 		))->first();
 		if(!$existingConfig) $existingConfig = SiteConfig::get()->first();
-		Translatable::enable_locale_filter();
+		if ($enabled) {
+			Translatable::enable_locale_filter();
+		}
 
 		// Stage this SiteConfig and copy into the current object
 		if(


### PR DESCRIPTION
This breaks code that tries to get all instances of SiteConfig like:

```
Translatable::disable_locale_filter();
$all = SiteConfig::get();
Translatable::enable_locale_filter();
```

What was happening was that our populateSiteConfigDefaults method was
getting called before the actual data list the users uses above is
created, so it was re-enabling the locale filter before the
augmentDataQuery function was called on the data list created for the
user. Thus, they'd get a locale-augmented query and only get the
SiteConfig for the current locale, and not all as clearly intended.
