### PR TITLE
Links in head will now include translated versions of each page including itself

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1466,18 +1466,18 @@ class Translatable extends DataExtension implements PermissionProvider {
 	 */
 	function MetaTags(&$tags) {
 		$template = '<link rel="alternate" type="text/html" title="%s" hreflang="%s" href="%s" />' . "\n";
-              	$translations = $this->owner->getTranslations();
+		$translations = $this->owner->getTranslations();
 		if($translations) {
-                        $translations = $translations->toArray();
-		        $translations[] = $this->owner;
-
-                        foreach($translations as $translation) {
-			        $tags .= sprintf($template,
-				        Convert::raw2xml($translation->Title),
-				        i18n::convert_rfc1766($translation->Locale),
-				        $translation->AbsoluteLink()
-			        );
-            	        }
+			$translations = $translations->toArray();
+			$translations[] = $this->owner;
+			
+		foreach($translations as $translation) {
+			$tags .= sprintf($template,
+				Convert::raw2xml($translation->Title),
+				i18n::convert_rfc1766($translation->Locale),
+				$translation->AbsoluteLink()
+				);
+			}
 		}
 	}
 	


### PR DESCRIPTION
Changes to reflect missing information in the head. Quote from Googles website (source below):
"If you have multiple language versions of a URL, each language page in the set must use rel="alternate" hreflang="x" to identify all language versions including itself."

https://support.google.com/webmasters/answer/189077?hl=en&ref_topic=2370587
