### PR TITLE
Correction on documentation regarding Setting the viewer's locale

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -336,7 +336,7 @@ By user preference (place this in your Page_Controller->init() method):
 	:::php
 	$member = Member::currentUser();
 	if($member && $member->Locale) {
-		Translatable::set_reading_locale($member->Locale);
+		Translatable::set_current_locale($member->Locale);
 	}
 
 ### Templates


### PR DESCRIPTION
Corrected Translatable docs in setting the locale based on $member->Locale to the correct method: Translatable::set_current_locale($member->Locale); instead of Translatable::set_reading_locale($member->Locale)
