### PR TITLE
FIX 63366327 breaking "Existing Translations" links

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1075,10 +1075,9 @@ class Translatable extends DataExtension implements PermissionProvider {
 						if($existingTranslation && $existingTranslation->hasMethod('CMSEditLink')) {
 							$existingTransHTML .= sprintf(
 								'<li><a href="%s">%s</a></li>',
-								sprintf(
-									'%s/?locale=%s', 
-									$existingTranslation->CMSEditLink(), 
-									$existingTranslation->Locale
+								Controller::join_links(
+									$existingTranslation->CMSEditLink(),
+									'?locale='.$existingTranslation->Locale
 								),
 								i18n::get_locale_name($existingTranslation->Locale)
 							);


### PR DESCRIPTION
CMSEditLink() was changed to always add a locale, but the link
creation for "Existing Translations" in Translatable#updateCMSFields
assumed there was no query string on the end of CMSEditLink()s return
value

Note that youll still end up with duplicate locale parameters after
this patch, but it will work as PHP always takes the last parameter
for preference. A seperate patch for Controller::join_links will
fix the duplicate parameters
