### PR TITLE
Use lowercase L for ?locale= in TranslatableCMSMainExtension->updateLinkPageAdd()

### DIFF
--- a/code/controller/TranslatableCMSMainExtension.php
+++ b/code/controller/TranslatableCMSMainExtension.php
@@ -155,7 +155,7 @@ class TranslatableCMSMainExtension extends Extension {
 
 	function updateLinkPageAdd(&$link) {
 		$locale = $this->owner->Locale ? $this->owner->Locale : Translatable::get_current_locale();
-		if($locale) $link = Controller::join_links($link, '?Locale=' . $locale);
+		if($locale) $link = Controller::join_links($link, '?locale=' . $locale);
 	}
 	
 	/**


### PR DESCRIPTION
This fixes links like this: `http://127.0.0.1:8080/admin/pages/add/?locale=en_US&Locale=en_US`

NOTE: there are several other places where Locale with uppercase L is used, which I believe can **not** be changed.

FormFields (need to be set with uppercase L to match DB field:
- [TranslatableCMSMainExtension.php Line 98](https://github.com/silverstripe/silverstripe-translatable/blob/03311b4d00348e946be854e9b2b71690b5fabea5/code/controller/TranslatableCMSMainExtension.php#L98)
- [TranslatableCMSMainExtension.php Line 103](https://github.com/silverstripe/silverstripe-translatable/blob/03311b4d00348e946be854e9b2b71690b5fabea5/code/controller/TranslatableCMSMainExtension.php#L103)
- [TranslatableCMSMainExtension.php Line 170](https://github.com/silverstripe/silverstripe-translatable/blob/03311b4d00348e946be854e9b2b71690b5fabea5/code/controller/TranslatableCMSMainExtension.php#L170)

Checks that check for Locale and locale:
- [TranslatableCMSMainExtension.php Line 27](https://github.com/silverstripe/silverstripe-translatable/blob/03311b4d00348e946be854e9b2b71690b5fabea5/code/controller/TranslatableCMSMainExtension.php#L27)
- [TranslatableCMSMainExtension.php Line 54](https://github.com/silverstripe/silverstripe-translatable/blob/03311b4d00348e946be854e9b2b71690b5fabea5/code/controller/TranslatableCMSMainExtension.php#L54)
