### PR TITLE
Avoid flagging pages as "modified"

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -710,7 +710,12 @@ class Translatable extends DataExtension implements PermissionProvider {
 					if(!$obj) continue;
 
 					$obj->Locale = Translatable::default_locale();
-					$obj->writeToStage($stage);
+					
+					$oldMode = Versioned::get_reading_mode();
+					Versioned::reading_stage($stage);
+					$obj->writeWithoutVersion();
+					Versioned::set_reading_mode($oldMode);
+					
 					$obj->addTranslationGroup($obj->ID);
 					$obj->destroy();
 					unset($obj);


### PR DESCRIPTION
I moved the internals of `writeToStage` in here, in order to be able to use `writeWithoutVersion`. Fixes bug #29. 
