### PR TITLE
Increase required core version from 3.2 to 4.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
 	],
 	"require": {
 		"php": ">=5.3.2",
-		"silverstripe/framework": "~3.2",
-		"silverstripe/cms": "~3.2"
+		"silverstripe/framework": "~4.0",
+		"silverstripe/cms": "~4.0"
 	},
 	"require-dev": {
 		"silverstripe/postgresql": "*",


### PR DESCRIPTION
Translatable::augmentSQL() follows new DataExtension signature, using SQLSelect rather than SQLQuery. Fixes #175