### PR TITLE
Compatibility with 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 # See https://github.com/silverstripe-labs/silverstripe-travis-support for setup details
 
 language: php 
-php: 
+php:
  - 5.3
  - 5.4
 
 env:
- - DB=MYSQL CORE_RELEASE=3.1
+  - DB=MYSQL CORE_RELEASE=3.1
+
+matrix:
+  include:
+    - php: 5.4
+      env: DB=MYSQL CORE_RELEASE=3
 
 before_script:
  - pear -q install --onlyreqdeps pear/PHP_CodeSniffer
@@ -16,5 +21,5 @@ before_script:
  - cd ~/builds/ss
 
 script: 
- - phpunit translatable/tests/
+ - vendor/bin/phpunit translatable/tests/
  - phpcs --encoding=utf-8 --tab-width=4 --standard=translatable/tests/phpcs -np translatable

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Note: This module was originally part of the SilverStripe CMS 2.x codebase.
 ## Requirements ##
 
  * SilverStripe Framework 3.1+ and CMS 3.1+
- * Note: For SilverStripe 2.3/2.4 support, please use the core built-in version (no module required)
 
 ## Maintainers ##
 

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,16 @@
 		}
 	],
 	"require": 
-		{
-			"php": ">=5.3.2",
-			"silverstripe/framework": "~3.1",
-			"silverstripe/cms": "~3.1"
-		},
+	{
+		"php": ">=5.3.2",
+		"silverstripe/framework": "~3.1",
+		"silverstripe/cms": "~3.1"
+	},
 	"require-dev": {
 		"silverstripe/postgresql": "*",
 		"silverstripe/sqlite3": "*",
-		"silverstripe/mssql": "*"
+		"silverstripe/mssql": "*",
+		"phpunit/PHPUnit": "~3.7@stable"
 	},
 	"extra":
 		{


### PR DESCRIPTION
3.2 still uses SQLQuery rather than SQLSelect,
but changes the getWhere() return signature.

Based on #185