### PR TITLE
Consistent locale casing, set locale on POST

### DIFF
--- a/code/controller/TranslatableCMSMainExtension.php
+++ b/code/controller/TranslatableCMSMainExtension.php
@@ -16,9 +16,6 @@ class TranslatableCMSMainExtension extends Extension {
 		// as an intermediary rather than the endpoint controller
 		if(!$this->owner->stat('tree_class')) return;
 
-		// Leave form submissions alone
-		if($req->httpMethod() != 'GET') return;
-
 		// Locale" attribute is either explicitly added by LeftAndMain Javascript logic,
 		// or implied on a translated record (see {@link Translatable->updateCMSFields()}).
 		// $Lang serves as a "context" which can be inspected by Translatable - hence it
@@ -48,14 +45,14 @@ class TranslatableCMSMainExtension extends Extension {
 		}
 		Translatable::set_current_locale($this->owner->Locale);
 
-		// if a locale is set, it needs to match to the current record
-		if($req->requestVar("Locale")) {
-			$requestLocale = $req->requestVar("Locale");
-		}
-		
+		// If a locale is set, it needs to match to the current record
+		$requestLocale = $req->requestVar("Locale");
 		$page = $this->owner->currentPage();
 		if(
-			$requestLocale && $page && $page->hasExtension('Translatable') 
+			$req->httpMethod() == 'GET' // leave form submissions alone
+			&& $requestLocale 
+			&& $page 
+			&& $page->hasExtension('Translatable') 
 			&& $page->Locale != $requestLocale
 			&& $req->latestParam('Action') != 'EditorToolbar'
 		) {

--- a/code/controller/TranslatableCMSMainExtension.php
+++ b/code/controller/TranslatableCMSMainExtension.php
@@ -26,8 +26,6 @@ class TranslatableCMSMainExtension extends Extension {
 		$id = $req->param('ID');
 		if($req->requestVar("Locale")) {
 			$this->owner->Locale = $req->requestVar("Locale");
-		} elseif($req->requestVar("locale")) {
-			$this->owner->Locale = $req->requestVar("locale");
 		} else if($id && is_numeric($id)) {
 			$record = DataObject::get_by_id($this->owner->stat('tree_class'), $id);
 			if($record && $record->Locale) $this->owner->Locale = $record->Locale;
@@ -53,8 +51,6 @@ class TranslatableCMSMainExtension extends Extension {
 		// if a locale is set, it needs to match to the current record
 		if($req->requestVar("Locale")) {
 			$requestLocale = $req->requestVar("Locale");
-		} else {
-			$requestLocale = $req->requestVar("locale");
 		}
 		
 		$page = $this->owner->currentPage();
@@ -75,7 +71,7 @@ class TranslatableCMSMainExtension extends Extension {
 				// If the record is not translated, redirect to pages overview
 				return $this->owner->redirect(Controller::join_links(
 					singleton('CMSPagesController')->Link(),
-					'?locale=' . $requestLocale
+					'?Locale=' . $requestLocale
 				));
 			}
 		}
@@ -140,12 +136,12 @@ class TranslatableCMSMainExtension extends Extension {
 
 	function updateLink(&$link) {
 		$locale = $this->owner->Locale ? $this->owner->Locale : Translatable::get_current_locale();
-		if($locale) $link = Controller::join_links($link, '?locale=' . $locale);
+		if($locale) $link = Controller::join_links($link, '?Locale=' . $locale);
 	}
 
 	function updateLinkWithSearch(&$link) {
 		$locale = $this->owner->Locale ? $this->owner->Locale : Translatable::get_current_locale();
-		if($locale) $link = Controller::join_links($link, '?locale=' . $locale);	
+		if($locale) $link = Controller::join_links($link, '?Locale=' . $locale);	
 	}
 
 	function updateExtraTreeTools(&$html) {
@@ -155,7 +151,7 @@ class TranslatableCMSMainExtension extends Extension {
 
 	function updateLinkPageAdd(&$link) {
 		$locale = $this->owner->Locale ? $this->owner->Locale : Translatable::get_current_locale();
-		if($locale) $link = Controller::join_links($link, '?locale=' . $locale);
+		if($locale) $link = Controller::join_links($link, '?Locale=' . $locale);
 	}
 	
 	/**

--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1119,7 +1119,7 @@ class Translatable extends DataExtension implements PermissionProvider {
 									'<li><a href="%s">%s</a></li>',
 									Controller::join_links(
 										$existingTranslation->CMSEditLink(),
-										'?locale=' . $existingTranslation->Locale
+										'?Locale=' . $existingTranslation->Locale
 									),
 									i18n::get_locale_name($existingTranslation->Locale)
 								);

--- a/javascript/CMSMain.Translatable.js
+++ b/javascript/CMSMain.Translatable.js
@@ -37,10 +37,10 @@
 			},
 			onchange: function(e) {
 				// Get new locale code
-				locale = {locale: $(e.target).val()};
+				var locale = {Locale: $(e.target).val()};
 				
 				// Check existing url
-				search = /locale=[^&]*/;
+				search = /Locale=[^&]*/;
 				url = document.location.href;
 				if(url.match(search)) {
 					// Replace locale code

--- a/javascript/HtmlEditorField.Translatable.js
+++ b/javascript/HtmlEditorField.Translatable.js
@@ -31,7 +31,7 @@
 			onchange: function(e) {
 				// reload tree with selected locale
 				var treeDropdown = $(this).parents('form').find('#internal .treedropdown');
-				treeDropdown.data('urlTree', $.path.addSearchParams(treeDropdown.data('urlTree').replace(/locale=[^&]*/, ''), 'locale='+$(this).val()));
+				treeDropdown.data('urlTree', $.path.addSearchParams(treeDropdown.data('urlTree').replace(/Locale=[^&]*/, ''), 'Locale='+$(this).val()));
 				treeDropdown.loadTree();
 			}
 		});


### PR DESCRIPTION
See #156 for some background. We don't want the `redirect()` calls to happen on POST requests, but do need the `$this->Locale` set so `TranslatableCMSMainExtension->updateLink()` can pick it up when called from `CMSPageAddController->doAdd()`. 

Technically the locale casing is a separate issue, but it was easier to fix them in the same go since they relate to the same code. In terms of GET params for view state, a lowercase `locale` makes more sense, but this conflicts with the automatic mapping in `Form->saveInto()` and the `Translatable.Locale` object property. So uppercase `Locale` is easier to standardise on. 

I guess the `Locale` uppercasing could be considered an API change, but none of the community modules building on translatable module seem to use it, hence we should be safe:
 * https://github.com/bummzack/translatable-dataobject/search?utf8=%E2%9C%93&q=locale
 * https://github.com/webbuilders-group/silverstripe-translatablerouting/search?utf8=%E2%9C%93&q=locale
 * https://github.com/Martimiz/silverstripe-translatablegooglesitemaps/search?utf8=%E2%9C%93&q=locale