### PR TITLE
Compatibility with SS3.2.0

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1899,7 +1899,7 @@ class Translatable_Transformation extends FormTransformation {
 	 * @param FormField $originalField The original editable field containing the translated value
 	 * @return CheckboxField The field with a modified label
 	 */
-	protected function transformCheckboxField(CheckboxField $nonEditableField, CheckboxField $originalField) {
+	protected function transformCheckboxField(FormField $nonEditableField, FormField $originalField) {
 		$label = $originalField->Title();
 		$fieldName = $originalField->getName();
 		$value = ($this->original->$fieldName) 


### PR DESCRIPTION
InlineFormAction doesn't get rendered correctly in CMS. Only text 'FormField' shows in CMS.

SS3.2.0 enables RECOVERABLE_ERRORs to get shown which breaks showing of Settings tab in translations of SiteTree objects.