### PR TITLE
BUGFIX: Fixed issue #213 causing crash when accessing a translation with a checkbox

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1897,7 +1897,7 @@ class Translatable_Transformation extends FormTransformation {
 	 * @param FormField $originalField The original editable field containing the translated value
 	 * @return CheckboxField The field with a modified label
 	 */
-	protected function transformCheckboxField(CheckboxField $nonEditableField, CheckboxField $originalField) {
+	protected function transformCheckboxField(CheckboxField_Readonly $nonEditableField, CheckboxField $originalField) {
 		$label = $originalField->Title();
 		$fieldName = $originalField->getName();
 		$value = ($this->original->$fieldName) 


### PR DESCRIPTION
Currently accessing a translation who's form contains a checkbox results in a crash (issue #213) caused by the first argument being passed is a CheckboxField_Readonly instance which is not a decedent of the CheckboxField class. This pull changes the first argument to expect an instance of CheckboxField_Readonly which allows the form to correctly display.

Generated error prior to this change
```
Argument 1 passed to Translatable_Transformation::transformCheckboxField() must be an instance of CheckboxField, instance of CheckboxField_Readonly given
```