### PR TITLE
Consistently add Locale to test fixtures (fixes #223)

### DIFF
--- a/tests/unit/TranslatableTest.yml
+++ b/tests/unit/TranslatableTest.yml
@@ -16,26 +16,32 @@ Page:
    parent:
       Title: Parent
       URLSegment: parent
+      Locale: en_US
    child1:
       Title: Child 1
       URLSegment: child1
       Parent: =>Page.parent
+      Locale: en_US
    child2:
       Title: Child 2
       URLSegment: child2
       Parent: =>Page.parent
+      Locale: en_US
    child3:
       Title: Child 3
       URLSegment: child3
       Parent: =>Page.parent
+      Locale: en_US
    grandchild1:
       Title: Grandchild
       URLSegment: grandchild1
       Parent: =>Page.child1
+      Locale: en_US
    grandchild2:
       Title: Grandchild
       URLSegment: grandchild2
       Parent: =>Page.child1
+      Locale: en_US
 TranslatableTest_DataObject:
    testobject_en:
       TranslatableProperty: en_US


### PR DESCRIPTION
Technically this should be fixed by changing the logic
in Translatable::get_extra_config(), which modifies the 'defaults'
configuration on the objects it applies to. Since this is called
very early during the configuration bootstrap, it sets whatever
the current value of Translatable::get_default_locale() is there.
Any changes at a later time don't affect newly created objects,
even Translatable::reset() doesn't alter the initially configured 'defaults'.