### PR TITLE
Fix link hreflang meta tags being output when there are no translations

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1577,12 +1577,12 @@ class Translatable extends DataExtension implements PermissionProvider {
 		if($translations->count()) {
 			$translations = $translations->toArray();
 			$translations[] = $this->owner;
-			
-		foreach($translations as $translation) {
-			$tags .= sprintf($template,
-				Convert::raw2xml($translation->Title),
-				i18n::convert_rfc1766($translation->Locale),
-				$translation->AbsoluteLink()
+
+			foreach($translations as $translation) {
+				$tags .= sprintf($template,
+					Convert::raw2xml($translation->Title),
+					i18n::convert_rfc1766($translation->Locale),
+					$translation->AbsoluteLink()
 				);
 			}
 		}

--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1574,7 +1574,7 @@ class Translatable extends DataExtension implements PermissionProvider {
 	function MetaTags(&$tags) {
 		$template = '<link rel="alternate" type="text/html" title="%s" hreflang="%s" href="%s" />' . "\n";
 		$translations = $this->owner->getTranslations();
-		if($translations) {
+		if($translations->count()) {
 			$translations = $translations->toArray();
 			$translations[] = $this->owner;
 			


### PR DESCRIPTION
It's recommended that the meta tag `<link rel="alternate" hreflang="en-us" href="http://www.example.com/usa/" />` is output only if there is more than one language variation of the page.