### PR TITLE
BUGFIX: Fixed potentential ambiguous column crash caused when query is joined to another table

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -932,7 +932,7 @@ class Translatable extends DataExtension implements PermissionProvider {
 				$fresh = Versioned::get_one_by_stage(
 					$baseDataClass,
 					Versioned::current_stage(),
-					'"ID" = ' . $this->owner->ID,
+					'"'.$baseDataClass.'"."ID" = ' . $this->owner->ID,
 					null
 				);
 				if ($fresh) {


### PR DESCRIPTION
When creating a translation it's possible to run into a ambiguous column "ID" crash when publishing an object if the query generated in the call to ``Versioned::get_one_by_stage()`` is joined against another table. This pull request simply prefixes the where parameter in the call with the base data class to avoid the potential crash.