### PR TITLE
Update Translatable.php

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1740,6 +1740,22 @@ class Translatable extends DataExtension implements PermissionProvider
                 );
             }
         }
+        else {
+			// Added to comply with current Google recommendations
+			// If no translations found for this page, add a self referencing hreflang tag so Google does not complain
+			// Language and Local tag
+			$tags .= sprintf($template,
+				Convert::raw2xml($this->owner->Title),
+				i18n::convert_rfc1766($this->owner->Locale),
+				$this->owner->AbsoluteLink()
+			);
+			// Language only tag
+			$tags .= sprintf($template,
+				Convert::raw2xml($this->owner->Title),
+				i18n::get_lang_from_locale($this->owner->Locale),
+				$this->owner->AbsoluteLink()
+			);
+		}
     }
     
     public function providePermissions()


### PR DESCRIPTION
I have an issue where when testing a site for hreflang tags Google throws errors about pages not having any hreflang tags. While this is not really a problem, my client wants to have it fixed. I have updated the Translatable.php file so if no translations are found for a given page it will return the self referencing hreflang tags for the page.