### PR TITLE
FIX make translatable field readonly if ->isReadOnly()

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1212,7 +1212,7 @@ class Translatable extends DataExtension implements PermissionProvider {
 				if(in_array($dataField->getName(), $translatableFieldNames)) {
 					// if the field is translatable, perform transformation
 					$fields->replaceField($dataField->getName(), $transformation->transformFormField($dataField));
-				} elseif(!$dataField->isReadonly()) {
+				} elseif($dataField->isReadonly()) {
 					// else field shouldn't be editable in translation-mode, make readonly
 					$fields->replaceField($dataField->getName(), $dataField->performReadonlyTransformation());
 				}


### PR DESCRIPTION
Fixes silverstripe/silverstripe-blog#442. 

The readonly logic in addTranslatableFields is negated for some reason, causing downstream issues with blog's FeaturedImage (and others of course) being transformed as readonly.