### PR TITLE
Update Translatable::MetaTags()

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1726,18 +1726,25 @@ class Translatable extends DataExtension implements PermissionProvider
      */
     public function MetaTags(&$tags)
     {
-        $template = '<link rel="alternate" type="text/html" title="%s" hreflang="%s" href="%s" />' . "\n";
-        $translations = $this->owner->getTranslations();
-        if ($translations) {
-            $translations = $translations->toArray();
-            $translations[] = $this->owner;
-            
-            foreach ($translations as $translation) {
-                $tags .= sprintf($template,
-                Convert::raw2xml($translation->Title),
-                i18n::convert_rfc1766($translation->Locale),
-                $translation->AbsoluteLink()
-                );
+        if (
+            ($controller = Controller::curr())
+            && count($controller->getRequest()->getVars())
+        ) {
+            $tags .= '<link rel="canonical" href="'.$controller->AbsoluteLink().'" />';
+        } else {
+            $template = '<link rel="alternate" type="text/html" title="%s" hreflang="%s" href="%s" />' . "\n";
+            $translations = $this->owner->getTranslations();
+            if($translations->count()) {
+                $translations = $translations->toArray();
+                $translations[] = $this->owner;
+
+                foreach($translations as $translation) {
+                    $tags .= sprintf($template,
+                        Convert::raw2xml($translation->Title),
+                        i18n::convert_rfc1766($translation->Locale),
+                        $translation->AbsoluteLink()
+                    );
+                }
             }
         }
     }

--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1731,20 +1731,20 @@ class Translatable extends DataExtension implements PermissionProvider
             && count($controller->getRequest()->getVars())
         ) {
             $tags .= '<link rel="canonical" href="'.$controller->AbsoluteLink().'" />';
-        } else {
-            $template = '<link rel="alternate" type="text/html" title="%s" hreflang="%s" href="%s" />' . "\n";
-            $translations = $this->owner->getTranslations();
-            if($translations->count()) {
-                $translations = $translations->toArray();
-                $translations[] = $this->owner;
+            return;
+        }
+        $template = '<link rel="alternate" type="text/html" title="%s" hreflang="%s" href="%s" />' . "\n";
+        $translations = $this->owner->getTranslations();
+        if($translations->count()) {
+            $translations = $translations->toArray();
+            $translations[] = $this->owner;
 
-                foreach($translations as $translation) {
-                    $tags .= sprintf($template,
-                        Convert::raw2xml($translation->Title),
-                        i18n::convert_rfc1766($translation->Locale),
-                        $translation->AbsoluteLink()
-                    );
-                }
+            foreach($translations as $translation) {
+                $tags .= sprintf($template,
+                    Convert::raw2xml($translation->Title),
+                    i18n::convert_rfc1766($translation->Locale),
+                    $translation->AbsoluteLink()
+                );
             }
         }
     }


### PR DESCRIPTION
There was an issue which causes `No return tags` issue in hreflang tags added in pages when the page link contains get params.

This [answer](https://webmasters.stackexchange.com/questions/110458/how-to-avoid-hreflang-return-errors-with-url-that-contain-parameters?answertab=votes#tab-top) suggests just add a canonical tag for the original page rather than adding hreflang tags.