### PR TITLE
Update Translatable::MetaTags() 

### DIFF
--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1572,6 +1572,13 @@ class Translatable extends DataExtension implements PermissionProvider {
 	 * @return string HTML
 	 */
 	function MetaTags(&$tags) {
+        if (
+            ($controller = Controller::curr())
+            && count($controller->getRequest()->getVars())
+        ) {
+            $tags .= '<link rel="canonical" href="'.$controller->AbsoluteLink().'" />';
+            return;
+        }
 		$template = '<link rel="alternate" type="text/html" title="%s" hreflang="%s" href="%s" />' . "\n";
 		$translations = $this->owner->getTranslations();
 		if($translations->count()) {

--- a/code/model/Translatable.php
+++ b/code/model/Translatable.php
@@ -1574,6 +1574,7 @@ class Translatable extends DataExtension implements PermissionProvider {
 	function MetaTags(&$tags) {
         if (
             ($controller = Controller::curr())
+            && $controller instanceof ContentController
             && count($controller->getRequest()->getVars())
         ) {
             $tags .= '<link rel="canonical" href="'.$controller->AbsoluteLink().'" />';


### PR DESCRIPTION
There was an issue which causes `No return tags` issue in hreflang tags added in pages when the page link contains get params. 

This link answer https://webmasters.stackexchange.com/questions/110458/how-to-avoid-hreflang-return-errors-with-url-that-contain-parameters?answertab=votes#tab-top suggests just add a canonical tag for the original page rather than adding hreflang tags.